### PR TITLE
bower main points only to unminified version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,7 @@
   "description": "Directive to show/hide password for Ionic apps.",
   "license": "MIT",
   "main": [
-    "./dist/ion-toggle-password.js",
-    "./dist/ion-toggle-password.min.js"
+    "./dist/ion-toggle-password.js"
   ],
   "keywords": [
     "AngularJS",


### PR DESCRIPTION
This way we avoid to have duplicate refs unminified and minified versions using "wiredep"

